### PR TITLE
Add CRC Checking

### DIFF
--- a/cross/HIDRelayController_cross.txt
+++ b/cross/HIDRelayController_cross.txt
@@ -43,6 +43,10 @@ led_bit = 1
 # The speed of the CPU clock, in Hz
 cpu_speed = 12000000
 
+# Check CRCs an use the fast (vs small) algorithm
+check_crc = true
+fast_crc = true
+
 # This is the port where the USB bus is connected. When you configure it to
 # "B", the registers PORTB, PINB and DDRB will be used.
 usb_ioport = 'B'

--- a/cross/dcttech_2ch_cross.txt
+++ b/cross/dcttech_2ch_cross.txt
@@ -24,6 +24,10 @@ num_relays = 2
 
 calibrate_oscillator = true
 
+# Check CRCs an use the fast (vs small) algorithm
+check_crc = true
+fast_crc = true
+
 # Controls which driver is used to set the relays. See: src/drivers/
 relay_driver = 'simple'
 relay_ioport = 'B'

--- a/cross/dcttech_8ch_cross.txt
+++ b/cross/dcttech_8ch_cross.txt
@@ -22,6 +22,10 @@ avrdude_part = 'm8'
 # Number of relays. Must be in the range [1..8]
 num_relays = 8
 
+# Check CRCs an use the fast (vs small) algorithm
+check_crc = true
+fast_crc = true
+
 # Controls which driver is used to set the relays. See: src/drivers/
 relay_driver = 'alacarte'
 relay_1_ioport = 'D'

--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,7 @@ usb_dplus_bit = meson.get_cross_property('usb_dplus_bit')
 num_relays = meson.get_cross_property('num_relays')
 enable_watchdog = meson.get_cross_property('enable_watchdog', true)
 calibrate_oscillator = meson.get_cross_property('calibrate_oscillator', false)
+check_crc = meson.get_cross_property('check_crc', true)
 
 assert(usb_ioport in ['A', 'B', 'C', 'D'], '"@0@" is not a valid I/O port'.format(usb_ioport))
 assert(num_relays >= 1 and num_relays <= 8, 'num_relays must be in the range [1..8]')
@@ -40,6 +41,7 @@ add_project_arguments(
     '-DREPORT_SERIAL=' + (get_option('usb_serial_id') ? '1' : '0'),
     '-DENABLE_WATCHDOG=' + (enable_watchdog ? '1' : '0'),
     '-DCALIBRATE_OSCILLATOR=' + (calibrate_oscillator ? '1' : '0'),
+    '-DCHECK_CRC=' + (check_crc ? '1' : '0'),
     language: 'c',
 )
 

--- a/meson.build
+++ b/meson.build
@@ -21,6 +21,7 @@ num_relays = meson.get_cross_property('num_relays')
 enable_watchdog = meson.get_cross_property('enable_watchdog', true)
 calibrate_oscillator = meson.get_cross_property('calibrate_oscillator', false)
 check_crc = meson.get_cross_property('check_crc', true)
+fast_crc = meson.get_cross_property('fast_crc', false)
 
 assert(usb_ioport in ['A', 'B', 'C', 'D'], '"@0@" is not a valid I/O port'.format(usb_ioport))
 assert(num_relays >= 1 and num_relays <= 8, 'num_relays must be in the range [1..8]')
@@ -37,6 +38,7 @@ add_project_arguments(
     '-DUSB_CFG_IOPORTNAME=' + usb_ioport,
     '-DUSB_CFG_DMINUS_BIT=' + usb_dminus_bit.to_string(),
     '-DUSB_CFG_DPLUS_BIT=' + usb_dplus_bit.to_string(),
+    '-DUSB_USE_FAST_CRC=' + (fast_crc ? '1' : '0'),
     '-DNUM_RELAYS=' + num_relays.to_string(),
     '-DREPORT_SERIAL=' + (get_option('usb_serial_id') ? '1' : '0'),
     '-DENABLE_WATCHDOG=' + (enable_watchdog ? '1' : '0'),

--- a/src/usbconfig.h
+++ b/src/usbconfig.h
@@ -216,7 +216,7 @@ void usbEventResetReady(void);
 /* define this macro to 1 if you want the function usbMeasureFrameLength()
  * compiled in. This function can be used to calibrate the AVR's RC oscillator.
  */
-#define USB_USE_FAST_CRC                0
+//#define USB_USE_FAST_CRC                0
 /* The assembler module has two implementations for the CRC algorithm. One is
  * faster, the other is smaller. This CRC routine is only used for transmitted
  * messages where timing is not critical. The faster routine needs 31 cycles

--- a/usbdrv/usbdrv.c
+++ b/usbdrv/usbdrv.c
@@ -428,6 +428,10 @@ usbRequest_t    *rq = (void *)data;
  * 0...0x0f for OUT on endpoint X
  */
     DBG2(0x10 + (usbRxToken & 0xf), data, len + 2); /* SETUP=1d, SETUP-DATA=11, OUTx=1x */
+#if CHECK_CRC
+    if (usbCrc16(data, len + 2) != 0x4FFE)
+        return;
+#endif
     USB_RX_USER_HOOK(data, len)
 #if USB_CFG_IMPLEMENT_FN_WRITEOUT
     if(usbRxToken < 0x10){  /* OUT to endpoint != 0: endpoint number in usbRxToken */


### PR DESCRIPTION
Adds Post-ACK CRC checking. This doesn't prevent V-USB from ACKing bad frames (as most devices don't have the CPU power to do this), but it does prevent interpreting corrupt data as valid.